### PR TITLE
Add tag flavor

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ Following inputs can be used as `step.with` keys
 | `tag-schedule`      | String   | [Template](#schedule-tag) to apply to schedule tag (default `nightly`) |
 | `sep-tags`          | String   | Separator to use for tags output (default `\n`) |
 | `sep-labels`        | String   | Separator to use for labels output (default `\n`) |
+| `flavor`            | String   | Tag suffix to be appended, specifying the image flavor (default ``) |
+| `main-flavor`       | String   | Enable tags without flavor suffix (default `true`) |
 
 > List/CSV type can be a newline or comma delimited string
 
@@ -305,6 +307,18 @@ If Git tag is a valid [semver](https://semver.org/) you can handle it to output 
 | `v2.0.8-beta.67`        | `v(\d.\d)`                         | `1`               | :white_check_mark:   | `2.0`, `latest`           | `2.0`                        |
 | `release1`              | `\d{1,3}.\d{1,3}`                  | `0`               | :x:                  | `release1`                | `release1`                   |
 | `20200110-RC2`          | `\d+`                              | `0`               | :white_check_mark:   | `20200110`, `latest`      | `20200110`                   |
+
+### `flavor` examples
+
+| Git tag                 | `flavor` | `main-flavor` | `tag-latest` | Output tags                                 |
+|-------------------------|----------|---------------|--------------|---------------------------------------------|
+| `v1.2.3`                | `debian` | `true`        | `true`       | `1.2.3-debian`, `1.2.3`, `debian`, `latest` |
+| `v1.2.3`                | `debian` | `true`        | `false`      | `1.2.3-debian`, `1.2.3`                     |
+| `v1.2.3`                | `alpine` | `false`       | `true`       | `1.2.3-alpine`, `alpine`                    |
+| `v1.2.3`                | `alpine` | `false`       | `false`      | `1.2.3-alpine`                              |
+| `v1.2.3`                | ``       | ``            | `true`       | `1.2.3`, `latest`                           |
+| `v1.2.3`                | ``       | ``            | `false`      | `1.2.3`                                     |
+
 
 ### Schedule tag
 

--- a/__tests__/meta.test.ts
+++ b/__tests__/meta.test.ts
@@ -1229,3 +1229,206 @@ describe('release', () => {
     ],
   ])('given %p event ', tagsLabelsTest);
 });
+
+describe('flavor', () => {
+  // prettier-ignore
+  test.each([
+    [
+      'event_release.env',
+      {
+        images: ['user/app'],
+        flavor: 'debian',
+        mainFlavor: true,
+      } as Inputs,
+      {
+        main: 'v1.1.1',
+        partial: [],
+        latest: true
+      } as Version,
+      [
+        'user/app:v1.1.1',
+        'user/app:v1.1.1-debian',
+        'user/app:latest',
+        'user/app:debian',
+      ],
+      [
+        "org.opencontainers.image.title=Hello-World",
+        "org.opencontainers.image.description=This your first repo!",
+        "org.opencontainers.image.url=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.source=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.version=v1.1.1",
+        "org.opencontainers.image.created=2020-01-10T00:30:00.000Z",
+        "org.opencontainers.image.revision=90dd6032fac8bda1b6c4436a2e65de27961ed071",
+        "org.opencontainers.image.licenses=MIT"
+      ]
+    ],
+    [
+      'event_release.env',
+      {
+        images: ['user/app'],
+        flavor: 'debian',
+        mainFlavor: true,
+        tagLatest: false,
+      } as Inputs,
+      {
+        main: 'v1.1.1',
+        partial: [],
+        latest: false,
+      } as Version,
+      [
+        'user/app:v1.1.1',
+        'user/app:v1.1.1-debian',
+      ],
+      [
+        "org.opencontainers.image.title=Hello-World",
+        "org.opencontainers.image.description=This your first repo!",
+        "org.opencontainers.image.url=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.source=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.version=v1.1.1",
+        "org.opencontainers.image.created=2020-01-10T00:30:00.000Z",
+        "org.opencontainers.image.revision=90dd6032fac8bda1b6c4436a2e65de27961ed071",
+        "org.opencontainers.image.licenses=MIT"
+      ]
+    ],
+    [
+      'event_release.env',
+      {
+        images: ['user/app'],
+        flavor: 'alpine',
+        mainFlavor: false,
+      } as Inputs,
+      {
+        main: 'v1.1.1',
+        partial: [],
+        latest: true
+      } as Version,
+      [
+        'user/app:v1.1.1-alpine',
+        'user/app:alpine',
+      ],
+      [
+        "org.opencontainers.image.title=Hello-World",
+        "org.opencontainers.image.description=This your first repo!",
+        "org.opencontainers.image.url=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.source=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.version=v1.1.1",
+        "org.opencontainers.image.created=2020-01-10T00:30:00.000Z",
+        "org.opencontainers.image.revision=90dd6032fac8bda1b6c4436a2e65de27961ed071",
+        "org.opencontainers.image.licenses=MIT"
+      ]
+    ],
+    [
+      'event_release.env',
+      {
+        images: ['user/app'],
+        flavor: 'alpine',
+        mainFlavor: false,
+        tagLatest: false,
+      } as Inputs,
+      {
+        main: 'v1.1.1',
+        partial: [],
+        latest: false
+      } as Version,
+      [
+        'user/app:v1.1.1-alpine',
+      ],
+      [
+        "org.opencontainers.image.title=Hello-World",
+        "org.opencontainers.image.description=This your first repo!",
+        "org.opencontainers.image.url=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.source=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.version=v1.1.1",
+        "org.opencontainers.image.created=2020-01-10T00:30:00.000Z",
+        "org.opencontainers.image.revision=90dd6032fac8bda1b6c4436a2e65de27961ed071",
+        "org.opencontainers.image.licenses=MIT"
+      ]
+    ],
+    [
+      'event_release.env',
+      {
+        images: ['user/app'],
+        flavor: '',
+        mainFlavor: true,
+        tagLatest: false,
+      } as Inputs,
+      {
+        main: 'v1.1.1',
+        partial: [],
+        latest: false
+      } as Version,
+      [
+        'user/app:v1.1.1',
+      ],
+      [
+        "org.opencontainers.image.title=Hello-World",
+        "org.opencontainers.image.description=This your first repo!",
+        "org.opencontainers.image.url=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.source=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.version=v1.1.1",
+        "org.opencontainers.image.created=2020-01-10T00:30:00.000Z",
+        "org.opencontainers.image.revision=90dd6032fac8bda1b6c4436a2e65de27961ed071",
+        "org.opencontainers.image.licenses=MIT"
+      ]
+    ],
+    [
+      'event_release.env',
+      {
+        images: ['user/app'],
+        flavor: '',
+        mainFlavor: false,
+        tagLatest: false,
+      } as Inputs,
+      {
+        main: 'v1.1.1',
+        partial: [],
+        latest: false
+      } as Version,
+      [
+        'user/app:v1.1.1',
+      ],
+      [
+        "org.opencontainers.image.title=Hello-World",
+        "org.opencontainers.image.description=This your first repo!",
+        "org.opencontainers.image.url=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.source=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.version=v1.1.1",
+        "org.opencontainers.image.created=2020-01-10T00:30:00.000Z",
+        "org.opencontainers.image.revision=90dd6032fac8bda1b6c4436a2e65de27961ed071",
+        "org.opencontainers.image.licenses=MIT"
+      ]
+    ],
+    [
+      'event_release.env',
+      {
+        images: ['user/app'],
+        tagSemver: ['{{version}}', '{{major}}.{{minor}}', '{{major}}'],
+        tagSha: true,
+        flavor: 'alpine',
+        mainFlavor: false,
+      } as Inputs,
+      {
+        main: '1.1.1',
+        partial: ['1.1', '1'],
+        latest: true
+      } as Version,
+      [
+        'user/app:1.1.1-alpine',
+        'user/app:1.1-alpine',
+        'user/app:1-alpine',
+        'user/app:alpine',
+        'user/app:sha-90dd603-alpine',
+      ],
+      [
+        "org.opencontainers.image.title=Hello-World",
+        "org.opencontainers.image.description=This your first repo!",
+        "org.opencontainers.image.url=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.source=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.version=1.1.1",
+        "org.opencontainers.image.created=2020-01-10T00:30:00.000Z",
+        "org.opencontainers.image.revision=90dd6032fac8bda1b6c4436a2e65de27961ed071",
+        "org.opencontainers.image.licenses=MIT"
+      ]
+    ],
+  ])('given %p event ', tagsLabelsTest);
+});

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,13 @@ inputs:
     description: 'GitHub Token as provided by secrets'
     default: ${{ github.token }}
     required: true
+  flavor:
+    description: 'Container flavor, with no leading dash, like "alpine" or "debian"'
+    required: false
+  main-flavor:
+    description: 'Create tags without flavor as well'
+    default: 'true'
+    required: false
 
 outputs:
   version:

--- a/src/context.ts
+++ b/src/context.ts
@@ -13,6 +13,8 @@ export interface Inputs {
   sepTags: string;
   sepLabels: string;
   githubToken: string;
+  flavor: string;
+  mainFlavor: boolean;
 }
 
 export function getInputs(): Inputs {
@@ -28,7 +30,9 @@ export function getInputs(): Inputs {
     tagSchedule: core.getInput('tag-schedule') || 'nightly',
     sepTags: core.getInput('sep-tags') || `\n`,
     sepLabels: core.getInput('sep-labels') || `\n`,
-    githubToken: core.getInput('github-token')
+    githubToken: core.getInput('github-token'),
+    flavor: core.getInput('flavor'),
+    mainFlavor: /true/i.test(core.getInput('main-flavor') || 'true')
   };
 }
 

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -100,18 +100,41 @@ export class Meta {
       return [];
     }
 
+    let flavor = this.inputs.flavor;
+    let main = !flavor || this.inputs.mainFlavor;
+
     let tags: Array<string> = [];
     for (const image of this.inputs.images) {
       const imageLc = image.toLowerCase();
-      tags.push(`${imageLc}:${this.version.main}`);
+      if (main) {
+        tags.push(`${imageLc}:${this.version.main}`);
+      }
+      if (flavor) {
+        tags.push(`${imageLc}:${this.version.main}-${flavor}`);
+      }
       for (const partial of this.version.partial) {
-        tags.push(`${imageLc}:${partial}`);
+        if (main) {
+          tags.push(`${imageLc}:${partial}`);
+        }
+        if (flavor) {
+          tags.push(`${imageLc}:${partial}-${flavor}`);
+        }
       }
       if (this.version.latest) {
-        tags.push(`${imageLc}:latest`);
+        if (main) {
+          tags.push(`${imageLc}:latest`);
+        }
+        if (flavor) {
+          tags.push(`${imageLc}:${flavor}`);
+        }
       }
       if (this.context.sha && this.inputs.tagSha) {
-        tags.push(`${imageLc}:sha-${this.context.sha.substr(0, 7)}`);
+        if (main) {
+          tags.push(`${imageLc}:sha-${this.context.sha.substr(0, 7)}`);
+        }
+        if (flavor) {
+          tags.push(`${imageLc}:sha-${this.context.sha.substr(0, 7)}-${flavor}`);
+        }
       }
     }
     return tags;


### PR DESCRIPTION
Fixes #13 

For cases where you have multiple flavors of the same container, like `node:12-alpine`, `node:12-debian`, etc, it would be nice to be able to specify these flavors in this github action. This was requested in #13.

Let's say that your container has two flavors, `debian` and `alpine`, and that you want images like `foo:latest` to be based on the debian flavor. You might want to generate these tags:

1. `foo:x.y.z-debian`
1. `foo:x.y.z-alpine`
1. `foo:x.y.z` (`= foo.x.y.z-debian`)
1. `foo:debian` (`= foo.x.y.z-debian`)
1. `foo:alpine` (`= foo.x.y.z-alpine`)
1. `foo:latest` (`= foo.x.y.z-debian`)
1. `foo:sha-AAAAAA-debian`
1. `foo:sha-AAAAAA-alpine`
1. `foo:sha-AAAAAA` (`= `foo:sha-AAAAAA-debian`)

To achieve this, I added two options: `flavor (string)` and `main-flavor (boolean)`. Trying to summarize their behavior:
- specifying a flavor will generate tags with the flavor suffix
- if no flavor is specified, or if there is a flavor but `main-flavor` is true, the flavorless tags will be emitted as well
- versionless flavorful tags (`foo:debian`) will only be generated if there's a flavor and the tag matches as `latest`.

In other words, each previously emited tag has its flavor counterpart:
- `foo:x.y.z` => `foo:x.y.z-{flavor}`
- `foo:latest` => `foo:{flavor}`
- `foo:sha-AAAAAA` => `foo:sha-AAAAAA-{flavor}`

And the left side are emited `if no flavor != '' or mainFlavor`, and the right side is emited `if flavor != ''`.

This is how I'm using this in a project:

```yaml
on:
  push:
    tags: '*.*.*'

jobs:
  release:
    strategy:
      matrix:
        base: [debian, alpine]
    steps:
      - uses:  hugopeixoto/ghaction-docker-meta@d08260d
        name: Docker meta
        id: docker_meta
        with:
          images: quay.io/hedgedoc/hedgedoc
          flavor: ${{ matrix.base }}
          main-flavor: ${{ matrix.base == 'debian' }}

```

I hope this is understandable :P Let me know what you think, and if this is an approach that makes sense. I wasn't sure if the `sha` tags should be flavored as well.

I still need to add tests and document this in the readme, but I'd like to know if this is something that you would consider integrate and iterate on before spending time there.