### PR TITLE
Use sepLabels when joining labels for output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -149,7 +149,7 @@ function run() {
                 core.info(label);
             }
             core.endGroup();
-            core.setOutput('labels', labels.join(inputs.sepTags));
+            core.setOutput('labels', labels.join(inputs.sepLabels));
         }
         catch (error) {
             core.setFailed(error.message);

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ async function run() {
       core.info(label);
     }
     core.endGroup();
-    core.setOutput('labels', labels.join(inputs.sepTags));
+    core.setOutput('labels', labels.join(inputs.sepLabels));
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
This PR fixes the Action's `labels` output to use the correct separator.