### PR TITLE
feat: add tag-suffix and tag-prefix options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,23 @@ jobs:
             ghcr.io/name/app
           tag-sha: true
 
+  tag-prefix-suffix:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        uses: ./
+        with:
+          images: |
+            ${{ env.DOCKER_IMAGE }}
+            ghcr.io/name/app
+          tag-sha: true
+          tag-prefix: prefix-
+          tag-suffix: -suffix
+
   tag-schedule:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ Following inputs can be used as `step.with` keys
 | `tag-schedule`      | String   | [Template](#schedule-tag) to apply to schedule tag (default `nightly`) |
 | `tag-custom`        | List/CSV | List of custom tags |
 | `tag-custom-only`   | Bool     | Only use `tag-custom` as Docker tags |
+| `tag-suffix`        | String   | Appends a string to the end of all Docker tags |
+| `tag-prefix`        | String   | Prepends a string to the beginning of all Docker tags |
 | `label-custom`      | List     | List of custom labels |
 | `sep-tags`          | String   | Separator to use for tags output (default `\n`) |
 | `sep-labels`        | String   | Separator to use for labels output (default `\n`) |

--- a/__tests__/meta.test.ts
+++ b/__tests__/meta.test.ts
@@ -135,6 +135,32 @@ describe('push', () => {
       ]
     ],
     [
+      'event_push.env',
+      {
+        images: ['user/app'],
+        tagPrefix: 'prepend-',
+        tagSuffix: '-append'
+      } as Inputs,
+      {
+        main: 'dev',
+        partial: [],
+        latest: false
+      } as Version,
+      [
+        'user/app:prepend-dev-append'
+      ],
+      [
+        "org.opencontainers.image.title=Hello-World",
+        "org.opencontainers.image.description=This your first repo!",
+        "org.opencontainers.image.url=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.source=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.version=dev",
+        "org.opencontainers.image.created=2020-01-10T00:30:00.000Z",
+        "org.opencontainers.image.revision=90dd6032fac8bda1b6c4436a2e65de27961ed071",
+        "org.opencontainers.image.licenses=MIT"
+      ]
+    ],
+    [
       'event_push_defbranch.env',
       {
         images: ['user/app'],
@@ -234,6 +260,33 @@ describe('push', () => {
       ]
     ],
     [
+      'event_push.env',
+      {
+        images: ['org/app', 'ghcr.io/user/app'],
+        tagPrefix: 'prepend-',
+        tagSuffix: '-append'
+      } as Inputs,
+      {
+        main: 'dev',
+        partial: [],
+        latest: false
+      } as Version,
+      [
+        'org/app:prepend-dev-append',
+        'ghcr.io/user/app:prepend-dev-append'
+      ],
+      [
+        "org.opencontainers.image.title=Hello-World",
+        "org.opencontainers.image.description=This your first repo!",
+        "org.opencontainers.image.url=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.source=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.version=dev",
+        "org.opencontainers.image.created=2020-01-10T00:30:00.000Z",
+        "org.opencontainers.image.revision=90dd6032fac8bda1b6c4436a2e65de27961ed071",
+        "org.opencontainers.image.licenses=MIT"
+      ]
+    ],
+    [
       'event_push_defbranch.env',
       {
         images: ['org/app', 'ghcr.io/user/app'],
@@ -275,6 +328,36 @@ describe('push', () => {
         'org/app:sha-90dd603',
         'ghcr.io/user/app:dev',
         'ghcr.io/user/app:sha-90dd603'
+      ],
+      [
+        "org.opencontainers.image.title=Hello-World",
+        "org.opencontainers.image.description=This your first repo!",
+        "org.opencontainers.image.url=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.source=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.version=dev",
+        "org.opencontainers.image.created=2020-01-10T00:30:00.000Z",
+        "org.opencontainers.image.revision=90dd6032fac8bda1b6c4436a2e65de27961ed071",
+        "org.opencontainers.image.licenses=MIT"
+      ]
+    ],
+    [
+      'event_push.env',
+      {
+        images: ['org/app', 'ghcr.io/user/app'],
+        tagSha: true,
+        tagPrefix: 'prepend-',
+        tagSuffix: '-append'
+      } as Inputs,
+      {
+        main: 'dev',
+        partial: [],
+        latest: false
+      } as Version,
+      [
+        'org/app:prepend-dev-append',
+        'org/app:prepend-sha-90dd603-append',
+        'ghcr.io/user/app:prepend-dev-append',
+        'ghcr.io/user/app:prepend-sha-90dd603-append'
       ],
       [
         "org.opencontainers.image.title=Hello-World",
@@ -334,6 +417,38 @@ describe('push', () => {
         'org/app:sha-90dd603',
         'ghcr.io/user/app:edge',
         'ghcr.io/user/app:sha-90dd603'
+      ],
+      [
+        "org.opencontainers.image.title=Hello-World",
+        "org.opencontainers.image.description=This your first repo!",
+        "org.opencontainers.image.url=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.source=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.version=edge",
+        "org.opencontainers.image.created=2020-01-10T00:30:00.000Z",
+        "org.opencontainers.image.revision=90dd6032fac8bda1b6c4436a2e65de27961ed071",
+        "org.opencontainers.image.licenses=MIT"
+      ]
+    ],
+    [
+      'event_push.env',
+      {
+        images: ['org/app', 'ghcr.io/user/app'],
+        tagSha: true,
+        tagEdge: true,
+        tagEdgeBranch: 'dev',
+        tagPrefix: 'prepend-',
+        tagSuffix: '-append'
+      } as Inputs,
+      {
+        main: 'edge',
+        partial: [],
+        latest: false
+      } as Version,
+      [
+        'org/app:prepend-edge-append',
+        'org/app:prepend-sha-90dd603-append',
+        'ghcr.io/user/app:prepend-edge-append',
+        'ghcr.io/user/app:prepend-sha-90dd603-append'
       ],
       [
         "org.opencontainers.image.title=Hello-World",
@@ -1314,6 +1429,36 @@ describe('custom', () => {
         'user/app:my',
         'user/app:custom',
         'user/app:tags'
+      ],
+      [
+        "org.opencontainers.image.title=Hello-World",
+        "org.opencontainers.image.description=This your first repo!",
+        "org.opencontainers.image.url=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.source=https://github.com/octocat/Hello-World",
+        "org.opencontainers.image.version=dev",
+        "org.opencontainers.image.created=2020-01-10T00:30:00.000Z",
+        "org.opencontainers.image.revision=90dd6032fac8bda1b6c4436a2e65de27961ed071",
+        "org.opencontainers.image.licenses=MIT"
+      ]
+    ],
+    [
+      'event_push.env',
+      {
+        images: ['user/app'],
+        tagCustom: ['my', 'custom', 'tags'],
+        tagPrefix: 'prepend-',
+        tagSuffix: '-append'
+      } as Inputs,
+      {
+        main: 'dev',
+        partial: ['my', 'custom', 'tags'],
+        latest: false
+      } as Version,
+      [
+        'user/app:prepend-dev-append',
+        'user/app:prepend-my-append',
+        'user/app:prepend-custom-append',
+        'user/app:prepend-tags-append'
       ],
       [
         "org.opencontainers.image.title=Hello-World",

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,12 @@ inputs:
   tag-custom-only:
     description: 'Only use tag-custom as Docker tags'
     required: false
+  tag-suffix:
+    description: 'Appends a string to the end of all Docker tags'
+    required: false
+  tag-prefix:
+    description: 'Prepends a string to the beginning of all Docker tags'
+    required: false
   label-custom:
     description: 'List of custom labels'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -66,6 +66,8 @@ function getInputs() {
         tagSchedule: core.getInput('tag-schedule') || 'nightly',
         tagCustom: getInputList('tag-custom'),
         tagCustomOnly: /true/i.test(core.getInput('tag-custom-only') || 'false'),
+        tagSuffix: core.getInput('tag-suffix'),
+        tagPrefix: core.getInput('tag-prefix'),
         labelCustom: getInputList('label-custom'),
         sepTags: core.getInput('sep-tags') || `\n`,
         sepLabels: core.getInput('sep-labels') || `\n`,
@@ -392,15 +394,15 @@ class Meta {
         let tags = [];
         for (const image of this.inputs.images) {
             const imageLc = image.toLowerCase();
-            tags.push(`${imageLc}:${this.version.main}`);
+            tags.push(`${imageLc}:${this.inputs.tagPrefix}${this.version.main}${this.inputs.tagSuffix}`);
             for (const partial of this.version.partial) {
-                tags.push(`${imageLc}:${partial}`);
+                tags.push(`${imageLc}:${this.inputs.tagPrefix}${partial}${this.inputs.tagSuffix}`);
             }
             if (this.version.latest) {
-                tags.push(`${imageLc}:latest`);
+                tags.push(`${imageLc}:${this.inputs.tagPrefix}latest${this.inputs.tagSuffix}`);
             }
             if (this.context.sha && this.inputs.tagSha) {
-                tags.push(`${imageLc}:sha-${this.context.sha.substr(0, 7)}`);
+                tags.push(`${imageLc}:${this.inputs.tagPrefix}sha-${this.context.sha.substr(0, 7)}${this.inputs.tagSuffix}`);
             }
         }
         return tags;

--- a/src/context.ts
+++ b/src/context.ts
@@ -18,6 +18,8 @@ export interface Inputs {
   tagSchedule: string;
   tagCustom: string[];
   tagCustomOnly: boolean;
+  tagSuffix: string;
+  tagPrefix: string;
   labelCustom: string[];
   sepTags: string;
   sepLabels: string;
@@ -44,6 +46,8 @@ export function getInputs(): Inputs {
     tagSchedule: core.getInput('tag-schedule') || 'nightly',
     tagCustom: getInputList('tag-custom'),
     tagCustomOnly: /true/i.test(core.getInput('tag-custom-only') || 'false'),
+    tagSuffix: core.getInput('tag-suffix'),
+    tagPrefix: core.getInput('tag-prefix'),
     labelCustom: getInputList('label-custom'),
     sepTags: core.getInput('sep-tags') || `\n`,
     sepLabels: core.getInput('sep-labels') || `\n`,

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -117,15 +117,15 @@ export class Meta {
     let tags: Array<string> = [];
     for (const image of this.inputs.images) {
       const imageLc = image.toLowerCase();
-      tags.push(`${imageLc}:${this.version.main}`);
+      tags.push(`${imageLc}:${this.inputs.tagPrefix}${this.version.main}${this.inputs.tagSuffix}`);
       for (const partial of this.version.partial) {
-        tags.push(`${imageLc}:${partial}`);
+        tags.push(`${imageLc}:${this.inputs.tagPrefix}${partial}${this.inputs.tagSuffix}`);
       }
       if (this.version.latest) {
-        tags.push(`${imageLc}:latest`);
+        tags.push(`${imageLc}:${this.inputs.tagPrefix}latest${this.inputs.tagSuffix}`);
       }
       if (this.context.sha && this.inputs.tagSha) {
-        tags.push(`${imageLc}:sha-${this.context.sha.substr(0, 7)}`);
+        tags.push(`${imageLc}:${this.inputs.tagPrefix}sha-${this.context.sha.substr(0, 7)}${this.inputs.tagSuffix}`);
       }
     }
     return tags;


### PR DESCRIPTION
Adds `tag-prefix` and `tag-suffix` options.

* `tag-prefix` will prepend the given string to the beginning of all Docker tags
    * e.g. If `tag-prefix` given is `prepend-`, `my/app:dev` becomes `my/app:prepend-dev`
* `tag-suffix` will append the given string to the end of all Docker tags
    * e.g. If `tag-suffix` given is `-append`, `my/app:dev` becomes `my/app:dev-append`
* Both options can be used simultaneously
* Added new tests
* All tests passing
* Followed [contribution guidelines](https://github.com/crazy-max/ghaction-docker-meta/blob/0a412843f87333854fa03a809b74056b64c6f31a/.github/CONTRIBUTING.md)

Addresses https://github.com/crazy-max/ghaction-docker-meta/issues/13